### PR TITLE
Fix flashing sign in link

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -11,7 +11,7 @@ export default class App extends React.Component {
   state = {
     challenges: [],
     url: '',
-    user: null,
+    user: undefined,
     users: {},
   };
 
@@ -45,6 +45,10 @@ export default class App extends React.Component {
     this.auth.onAuthStateChanged((user) => {
       if (user) {
         this.setUser(user);
+      } else {
+        this.setState({
+          user: null,
+        });
       }
     });
   }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -74,7 +74,11 @@ export default class Header extends React.Component {
       );
     }
 
-    return <StyledButtonLink onClick={signIn}>Sign in</StyledButtonLink>;
+    if (user === null) {
+      return <StyledButtonLink onClick={signIn}>Sign in</StyledButtonLink>;
+    }
+
+    return null;
   }
 
   render() {
@@ -90,14 +94,10 @@ export default class Header extends React.Component {
 }
 
 Header.propTypes = {
-  user: PropTypes.shape({
+  user: PropTypes.shape({ // eslint-disable-line react/require-default-props
     displayName: PropTypes.string.isRequired,
     photoURL: PropTypes.string.isRequired,
   }),
   signIn: PropTypes.func.isRequired,
   signOut: PropTypes.func.isRequired,
-};
-
-Header.defaultProps = {
-  user: null,
 };


### PR DESCRIPTION
Set the user to `undefined` before auth data is loaded. This (subtle) change allows us to tell if the user data is still loading, and if it is, don't show the sign in or user info yet.