### PR TITLE
Refactor data structures

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -61,7 +61,10 @@ class App extends React.Component {
       const user = { displayName, email, photoURL };
       this.usersRef.child(uid).set(user);
       this.setState({
-        user: { ...user, uid },
+        user: {
+          ...user,
+          id: uid,
+        },
         error: null,
       }, onSuccess);
     } else {
@@ -119,7 +122,7 @@ class App extends React.Component {
             tags,
             url,
             slug,
-            contributor: this.state.user.uid,
+            contributor: this.state.user.id,
           });
           this.setState({
             url: '',

--- a/src/components/ChallengeCard.js
+++ b/src/components/ChallengeCard.js
@@ -85,14 +85,17 @@ const StyledTag = styled.li`
   }
 `;
 
-export default function ChallengeCard({ challenge, link, contributor, tags }) {
+export default function ChallengeCard({ challenge, link, tags }) {
   return (
     <StyledChallengeCard>
       <StyledCardTop>
         <StyledContributorWrapper>
-          <Avatar src={contributor.photoURL} alt={contributor.displayName} />
+          <Avatar
+            src={challenge.contributor.photoURL}
+            alt={challenge.contributor.displayName}
+          />
           <div>
-            <p>{contributor.displayName}</p>
+            <p>{challenge.contributor.displayName}</p>
             <p>{format(challenge.createdAt, 'MMMM D, YYYY')}</p>
           </div>
         </StyledContributorWrapper>
@@ -116,16 +119,17 @@ export default function ChallengeCard({ challenge, link, contributor, tags }) {
 
 ChallengeCard.propTypes = {
   challenge: PropTypes.shape({
+    contributor: PropTypes.shape({
+      displayName: PropTypes.string.isRequired,
+      photoURL: PropTypes.string.isRequired,
+    }).isRequired,
+    createdAt: PropTypes.number.isRequired,
     description: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     points: PropTypes.string.isRequired,
   }).isRequired,
   link: PropTypes.element,
-  tags: PropTypes.array,
-  contributor: PropTypes.shape({
-    displayName: PropTypes.string.isRequired,
-    photoURL: PropTypes.string.isRequired,
-  }).isRequired,
+  tags: PropTypes.arrayOf(PropTypes.string),
 };
 
 ChallengeCard.defaultProps = {

--- a/src/components/ChallengeList.js
+++ b/src/components/ChallengeList.js
@@ -11,7 +11,7 @@ const StyledChallengeList = styled.ul`
   padding-left: 0;
 `;
 
-export default function ChallengeList({ challenges, users }) {
+export default function ChallengeList({ challenges }) {
   return (
     <StyledChallengeList>
       {challenges
@@ -23,7 +23,6 @@ export default function ChallengeList({ challenges, users }) {
               link={
                 <StyledButton to={`challenge/${challenge.slug}`}>Solve</StyledButton>
               }
-              contributor={users[challenge.contributor]}
             />
           </li>
         ))
@@ -33,6 +32,9 @@ export default function ChallengeList({ challenges, users }) {
 }
 
 ChallengeList.propTypes = {
-  challenges: PropTypes.array.isRequired,
-  users: PropTypes.object.isRequired,
+  challenges: PropTypes.arrayOf(PropTypes.shape({
+    createdAt: PropTypes.number.isRequired,
+    id: PropTypes.string.isRequired,
+    slug: PropTypes.string.isRequired,
+  })).isRequired,
 };

--- a/src/components/ChallengePage.js
+++ b/src/components/ChallengePage.js
@@ -48,7 +48,7 @@ export default class ChallengePage extends React.Component {
 
   renderSubmissions() {
     const { users, user, signIn, contributor } = this.props;
-    if (user && this.state.submissions.find(submission => submission.author === user.uid)) {
+    if (user && this.state.submissions.find(submission => submission.author === user.id)) {
       return (
         <SubmissionList
           users={users}
@@ -115,7 +115,7 @@ ChallengePage.propTypes = {
     photoURL: PropTypes.string.isRequired,
   }).isRequired,
   user: PropTypes.shape({
-    uid: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
   }),
   signIn: PropTypes.func.isRequired,
   users: PropTypes.object.isRequired,

--- a/src/components/ChallengePage.js
+++ b/src/components/ChallengePage.js
@@ -9,6 +9,7 @@ import { StyledExternalLink } from './StyledButton';
 import SubmissionList from './SubmissionList';
 import SubmissionForm from './SubmissionForm';
 import ErrorMessage from './ErrorMessage';
+import addIdToItems from '../utils/addIdToItems';
 
 const StyledColumn = styled.div`
   flex: 1;
@@ -34,12 +35,8 @@ export default class ChallengePage extends React.Component {
   componentDidMount() {
     this.submissionsRef = firebase.database().ref(`submissions/${this.props.challenge.id}`);
     this.submissionsRef.on('value', (snapshot) => {
-      const submissions = snapshot.val() || {};
       this.setState({
-        submissions: Object.entries(submissions).map(([key, submission]) => ({
-          ...submission,
-          id: key,
-        })),
+        submissions: addIdToItems(snapshot.val() || {}),
         isLoading: false,
       });
     });

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -6,15 +6,7 @@ import ChallengeList from './ChallengeList';
 import { StyledHomeContent } from './Content';
 import ErrorMessage from './ErrorMessage';
 
-export default function HomePage({
-  handleChange,
-  handleSubmit,
-  url,
-  challenges,
-  users,
-  error,
-  user,
-}) {
+export default function HomePage({ handleChange, handleSubmit, url, challenges, error, user }) {
   return (
     <StyledHomeContent>
       {error &&
@@ -26,18 +18,17 @@ export default function HomePage({
         url={url}
         user={user}
       />
-      <ChallengeList challenges={challenges} users={users} />
+      <ChallengeList challenges={challenges} />
     </StyledHomeContent>
   );
 }
 
 HomePage.propTypes = {
+  challenges: PropTypes.array.isRequired,
+  error: PropTypes.string,
   handleChange: PropTypes.func.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   url: PropTypes.string.isRequired,
-  challenges: PropTypes.array.isRequired,
-  users: PropTypes.object.isRequired,
-  error: PropTypes.string,
   user: PropTypes.object, // eslint-disable-line react/require-default-props
 };
 

--- a/src/components/SubmissionForm.js
+++ b/src/components/SubmissionForm.js
@@ -71,7 +71,7 @@ export default class SubmissionForm extends React.Component {
     submissionsRef.push({
       createdAt: firebase.database.ServerValue.TIMESTAMP,
       solution: this.state.solution,
-      author: user.uid,
+      author: user.id,
     });
     this.setState({
       solution: '',
@@ -196,7 +196,7 @@ export default class SubmissionForm extends React.Component {
 
 SubmissionForm.propTypes = {
   user: PropTypes.shape({
-    uid: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
   }),
   signIn: PropTypes.func.isRequired,
   submissionsRef: PropTypes.object,

--- a/src/components/SubmissionList.js
+++ b/src/components/SubmissionList.js
@@ -49,7 +49,7 @@ const StyledSolution = styled.article`
   }
 `;
 
-export default function SubmissionList({ users, submissions }) {
+export default function SubmissionList({ submissions }) {
   return (
     <StyledSubmissionList>
       {submissions
@@ -58,11 +58,11 @@ export default function SubmissionList({ users, submissions }) {
           <StyledSubmission key={submission.id}>
             <StyledAuthorWrapper>
               <Avatar
-                src={users[submission.author].photoURL}
-                alt={users[submission.author].displayName}
+                src={submission.author.photoURL}
+                alt={submission.author.displayName}
               />
               <div>
-                <p className="author-name">{users[submission.author].displayName}</p>
+                <p className="author-name">{submission.author.displayName}</p>
                 <p className="author-date">{format(submission.createdAt, 'MMMM D, YYYY h:mma')}</p>
               </div>
             </StyledAuthorWrapper>
@@ -79,8 +79,15 @@ export default function SubmissionList({ users, submissions }) {
 }
 
 SubmissionList.propTypes = {
-  users: PropTypes.object.isRequired,
-  submissions: PropTypes.array,
+  submissions: PropTypes.arrayOf(PropTypes.shape({
+    author: PropTypes.shape({
+      displayName: PropTypes.string.isRequired,
+      photoURL: PropTypes.string.isRequired,
+    }).isRequired,
+    createdAt: PropTypes.number.isRequired,
+    id: PropTypes.string.isRequired,
+    solution: PropTypes.string.isRequired,
+  })),
 };
 
 SubmissionList.defaultProps = {

--- a/src/utils/addIdToItems.js
+++ b/src/utils/addIdToItems.js
@@ -1,0 +1,3 @@
+export default function addIdToItems(items) {
+  return Object.entries(items).map(([id, item]) => ({ ...item, id }));
+}

--- a/src/utils/addIdToItems.js
+++ b/src/utils/addIdToItems.js
@@ -1,3 +1,0 @@
-export default function addIdToItems(items) {
-  return Object.entries(items).map(([id, item]) => ({ ...item, id }));
-}


### PR DESCRIPTION
This PR basically just refactors how some of the data stored in Firebase is named and structured once it's in the app:

- [x] Don't save entity ID attributes as part of the data in Firebase since the Firebase key is already the ID
- [x] Add the entity IDs back when loading into app state
- [x] Rename a user's `uid` attribute to just `id`
- [x] Replace the user ID stored under a challenge's `contributor` attribute and a submission's `author` attribute with the actual data corresponding to that user ID

Helps with #34.